### PR TITLE
Pipeline comments and release-drafter only on tagged version

### DIFF
--- a/template/.github/workflows/codeql-analysis.yml
+++ b/template/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,7 @@
-# This pipeline
+# CodeQL is the code analysis engine developed by GitHub to automate security checks.
+#
+# For more information see: https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql
+
 
 name: "CodeQL"
 

--- a/template/.github/workflows/documentation-build.yml
+++ b/template/.github/workflows/documentation-build.yml
@@ -3,6 +3,8 @@
 # - pushes documentation to gh-pages branch of the same repository
 #
 # Deployment is handled by pages-build-deployment bot
+#
+# For more information see: https://docs.github.com/en/pages/getting-started-with-github-pages
 
 name: Build Documentation and Push to gh-pages Branch
 

--- a/template/.github/workflows/ossar-analysis.yml
+++ b/template/.github/workflows/ossar-analysis.yml
@@ -1,6 +1,9 @@
 # This workflow integrates a collection of open source static analysis tools
-# with GitHub code scanning. For documentation, or to provide feedback, visit
-# https://github.com/github/ossar-action
+# with GitHub code scanning.
+#
+# For more information see: https://github.com/github/ossar-action
+
+
 name: OSSAR
 
 on:

--- a/template/.github/workflows/python-publish.yml
+++ b/template/.github/workflows/python-publish.yml
@@ -4,6 +4,7 @@
 #
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
+
 name: Publish Python Package
 
 # Controls when the workflow will run

--- a/template/.github/workflows/release-drafter-verify-pr-labels.yml
+++ b/template/.github/workflows/release-drafter-verify-pr-labels.yml
@@ -1,7 +1,7 @@
 # This workflow will
 # - verify that a PR has a known label before it can be merged.
 #
-# A PR is enforced to have one of the labels listed in the valid-labels input. 
+# A PR is enforced to have one of the labels listed in the valid-labels input.
 #
 # For more information see: https://github.com/marketplace/actions/release-drafter
 

--- a/template/.github/workflows/release-drafter-verify-pr-labels.yml
+++ b/template/.github/workflows/release-drafter-verify-pr-labels.yml
@@ -1,6 +1,8 @@
-# This workflow will be verify that all PRs have at
-# least on the label: 'bugs', 'enhancement' before
-# they can be merged.
+# This workflow will
+# - verify that a PR has a known label before it can be merged.
+#
+# A PR shold have one of the labels listed in the `valid-labels` input. 
+
 
 name: Verify PR labels
 on:

--- a/template/.github/workflows/release-drafter-verify-pr-labels.yml
+++ b/template/.github/workflows/release-drafter-verify-pr-labels.yml
@@ -1,7 +1,7 @@
 # This workflow will
 # - verify that a PR has a known label before it can be merged.
 #
-# A PR is enforced to have one of the labels listed in the `valid-labels` input. 
+# A PR is enforced to have one of the labels listed in the valid-labels input. 
 #
 # For more information see: https://github.com/marketplace/actions/release-drafter
 

--- a/template/.github/workflows/release-drafter-verify-pr-labels.yml
+++ b/template/.github/workflows/release-drafter-verify-pr-labels.yml
@@ -1,7 +1,9 @@
 # This workflow will
 # - verify that a PR has a known label before it can be merged.
 #
-# A PR shold have one of the labels listed in the `valid-labels` input. 
+# A PR is enforced to have one of the labels listed in the `valid-labels` input. 
+#
+# For more information see: https://github.com/marketplace/actions/release-drafter
 
 
 name: Verify PR labels

--- a/template/.github/workflows/release-drafter.yml
+++ b/template/.github/workflows/release-drafter.yml
@@ -1,16 +1,23 @@
+# This workflow will
+# - draft a new release the next time a release is tagged.
+#
+# Uses the release-drafter.yml configuration file in the .github directory.
+#
+# For more information see: https://github.com/marketplace/actions/release-drafter
+
+
 name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
-    branches:
-      - pre-release
+    tags:
+      - 'v*'
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR:

The release drafter is now only executed when a commit is tagged with a version (`v*`)

Added comments to all pipelines describing what they are doing.